### PR TITLE
Fix typo already fixed in redis module name

### DIFF
--- a/src/redis/mcaptcha_redis.rs
+++ b/src/redis/mcaptcha_redis.rs
@@ -45,7 +45,7 @@ const ADD_CHALLENGE: &str = "MCAPTCHA_CACHE.ADD_CHALLENGE";
 const GET_CHALLENGE: &str = "MCAPTCHA_CACHE.GET_CHALLENGE";
 const DELETE_CHALLENGE: &str = "MCAPTCHA_CACHE.DELETE_CHALLENGE";
 
-const MODULE_NAME: &str = "mcaptcha_cahce";
+const MODULE_NAME: &str = "mcaptcha_cache";
 
 impl MCaptchaRedis {
     /// Get new [MCaptchaRedis]. Use this when executing commands that are


### PR DESCRIPTION
While building mcaptcha and redis cache module from source, I was not able to start mcaptcha because of the MCaptchaRedisModuleIsNotLoaded error.

This is related to https://github.com/mCaptcha/cache/commit/f30bc54e6374cf5fad07af8f3d38bbe5fbbb4b20