### PR TITLE
fix: pin pow_sha256 to tag 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pow_sha256"
 version = "0.3.1"
-source = "git+https://github.com/mcaptcha/pow_sha256#3b4e28706a8946987ba02f98e1f816d9fa156dad"
+source = "git+https://github.com/mcaptcha/pow_sha256?tag=0.3.1#3b4e28706a8946987ba02f98e1f816d9fa156dad"
 dependencies = [
  "bincode",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ derive_more = "0.99"
 rand = {version = "0.8",  optional = true }
 
 
-pow_sha256 = { version = "0.3.1", git = "https://github.com/mcaptcha/pow_sha256", optional=true }
+pow_sha256 = { version = "0.3.1", git = "https://github.com/mcaptcha/pow_sha256", optional=true, tag="0.3.1" }
 redis = { version = "0.21", features = ["tokio-comp","aio","r2d2", "connection-manager", "cluster"], optional=true }
 #redis = { version = "0.17.0", features = ["tokio-comp","aio", "cluster"], optional=true }
 


### PR DESCRIPTION
We noticed that pow_sha256 appears twice in the `Cargo.lock` file in mCaptcha
https://github.com/mCaptcha/mCaptcha/blob/f337ee0643d88723776e1de4e5588dfdb6c0c574/Cargo.lock#L2290-L2312
```toml
[[package]]
name = "pow_sha256"
version = "0.3.1"
source = "git+https://github.com/mcaptcha/pow_sha256?tag=0.3.1#3b4e28706a8946987ba02f98e1f816d9fa156dad"
dependencies = [
 "bincode",
 "derive_builder",
 "num",
 "serde 1.0.147",
 "sha2",
]

[[package]]
name = "pow_sha256"
version = "0.3.1"
source = "git+https://github.com/mcaptcha/pow_sha256#148f1cb70d19114d1340661a77b2b679e95715f6"
dependencies = [
 "bincode",
 "derive_builder",
 "num",
 "serde 1.0.147",
 "sha2",
]
```

This PR allows Cargo to de-duplicate the dependencies.