### PR TITLE
src/redis/mcaptcha_redis: Allow mcaptcha_cache redis module to not be first in module list

### DIFF
--- a/src/redis/mcaptcha_redis.rs
+++ b/src/redis/mcaptcha_redis.rs
@@ -70,13 +70,9 @@ impl MCaptchaRedis {
 impl MCaptchaRedisConnection {
     async fn is_module_loaded(&self) -> CaptchaResult<()> {
         if let Value::Bulk(s) = self.0.exec(redis::cmd("MODULE").arg("LIST")).await.unwrap() {
-            if let Some(Value::Bulk(s)) = s.first() {
-                match s.iter().find(|i| format!("{:?}", i).contains(MODULE_NAME)) {
-                    Some(_) => (),
-                    None => return Err(CaptchaError::MCaptchaRedisModuleIsNotLoaded),
-                }
-            } else {
-                return Err(CaptchaError::MCaptchaRedisModuleIsNotLoaded);
+            match s.iter().find(|i| format!("{:?}", i).contains(MODULE_NAME)) {
+                Some(_) => (),
+                None => return Err(CaptchaError::MCaptchaRedisModuleIsNotLoaded),
             }
         }
 


### PR DESCRIPTION
(Please bear with me, I wouldn't call myself much of a Rust programmer)

In NGIpkgs, we have mCaptcha packaged and verify its functionality with some VM tests. We were having issues with mCaptcha sometimes incorrectly deciding that the Redis server it's talking to doesn't have the `mcaptcha_cache` module loaded:

```
mcaptcha # [    8.016137] systemd[1]: Starting Redis Server - redis-mcaptcha...
[...]
mcaptcha # [    8.256870] redis-server[879]: Supervised by systemd. Please make sure you set appropriate values for TimeoutStartSec and TimeoutStopSec in your service unit.
mcaptcha # [    8.259288] redis-server[879]: oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
mcaptcha # [    8.261103] redis-server[879]: Redis version=8.0.3, bits=64, commit=00000000, modified=0, pid=879, just started
mcaptcha # [    8.263135] redis-server[879]: Configuration loaded
mcaptcha # [    8.264776] redis[879]: monotonic clock: POSIX clock_gettime
mcaptcha # [    8.269559] redis[879]: Running mode=standalone, port=6379.
mcaptcha # [    8.277889] redis[879]: <mcaptcha_cache> Created new data type 'mcaptbuck'
mcaptcha # [    8.279726] redis[879]: <mcaptcha_cache> Created new data type 'mcaptmcap'
mcaptcha # [    8.281202] redis[879]: <mcaptcha_cache> Created new data type 'mcaptsafe'
mcaptcha # [    8.283154] redis[879]: <mcaptcha_cache> Created new data type 'mcaptchal'
mcaptcha # [    8.284430] redis[879]: Module 'mcaptcha_cache' loaded from /nix/store/zx03cwkx3lgbiszrdp7b5i1r1r4g4wr1-cache-0.1.0/lib/libcache.so
mcaptcha # [    8.286909] redis[879]: Server initialized
mcaptcha # [    8.288317] redis[879]: Ready to accept connections tcp
mcaptcha # [    8.289348] redis[879]: Ready to accept connections unix
mcaptcha # [    8.292336] systemd[1]: Started Redis Server - redis-mcaptcha.
[...]
mcaptcha # [   16.288103] systemd[1]: Started mCaptcha: a CAPTCHA system that gives attackers a run for their money.
[...]
mcaptcha # [   16.376122] mcaptcha-start[1049]:  INFO  mcaptcha > mcaptcha: mCaptcha - a PoW-based CAPTCHA system.
mcaptcha # [   16.377609] mcaptcha-start[1049]: For more information, see: https://mcaptcha.org
mcaptcha # [   16.378834] mcaptcha-start[1049]: Build info:
mcaptcha # [   16.379589] mcaptcha-start[1049]: Version: 0.1.0 commit: v0.1.0
mcaptcha # [   16.381293] mcaptcha-start[1049]:  INFO  mcaptcha::settings > Loading config file from /nix/store/0slcmkrm67hb7bp1pvdg1rs27agpwjs5-mcaptcha.config.toml
mcaptcha # [   16.391412] mcaptcha-start[1049]:  INFO  mcaptcha::data     > Initializing credential manager
mcaptcha # [   16.510358] mcaptcha-start[1049]: thread 'main' panicked at src/data.rs:142:22:
mcaptcha # [   16.512244] mcaptcha-start[1049]: called `Result::unwrap()` on an `Err` value: MCaptchaRedisModuleIsNotLoaded
mcaptcha # [   16.514552] mcaptcha-start[1049]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
mcaptcha # [   16.523597] systemd[1]: mcaptcha.service: Main process exited, code=exited, status=101/n/a
mcaptcha # [   16.525169] systemd[1]: mcaptcha.service: Failed with result 'exit-code'.
```

I debugged this in https://github.com/ngi-nix/ngipkgs/pull/1464 down to this code, where only the first received module entry is checked. But the order of the module listings which this code gets from Redis doesn't always seem to have `mcaptcha_cache` at the first position. On some runs, it's:
```
mcaptcha # [   14.189538] mcaptcha-start[1031]:  ERROR libmcaptcha::redis::mcaptcha_redis > mCaptcha redis module list entry: bulk(string-data('"name"'), string-data('"mcaptcha_cache"'), string-data('"ver"'), int(0), string-data('"path"'), string-data('"/nix/store/zx03cwkx3lgbiszrdp7b5i1r1r4g4wr1-cache-0.1.0/lib/libcache.so"'), string-data('"args"'), bulk())
mcaptcha # [   14.193327] mcaptcha-start[1031]:  ERROR libmcaptcha::redis::mcaptcha_redis > mCaptcha redis module list entry: bulk(string-data('"name"'), string-data('"vectorset"'), string-data('"ver"'), int(1), string-data('"path"'), string-data('""'), string-data('"args"'), bulk())
```

Other times, it's:
```
mcaptcha # [   19.134242] mcaptcha-start[1069]:  ERROR libmcaptcha::redis::mcaptcha_redis > mCaptcha redis module list entry: bulk(string-data('"name"'), string-data('"vectorset"'), string-data('"ver"'), int(1), string-data('"path"'), string-data('""'), string-data('"args"'), bulk())
mcaptcha # [   19.137870] mcaptcha-start[1069]:  ERROR libmcaptcha::redis::mcaptcha_redis > mCaptcha redis module list entry: bulk(string-data('"name"'), string-data('"mcaptcha_cache"'), string-data('"ver"'), int(0), string-data('"path"'), string-data('"/nix/store/zx03cwkx3lgbiszrdp7b5i1r1r4g4wr1-cache-0.1.0/lib/libcache.so"'), string-data('"args"'), bulk())
```

This PR drops the `s.first()` call, and just checks the entire list for the `mcaptcha_cache` module.