### PR TITLE
fix: don't panic RedisCache actor when result receiver is dropped

### DIFF
--- a/src/cache/redis.rs
+++ b/src/cache/redis.rs
@@ -57,7 +57,7 @@ impl Handler<CachePoW> for RedisCache {
             };
 
             let res = con.add_challenge(&msg.key, &payload).await;
-            tx.send(res).unwrap();
+            let _ = tx.send(res);
         }
         .into_actor(self);
         ctx.wait(fut);
@@ -86,7 +86,7 @@ impl Handler<RetrivePoW> for RedisCache {
                 }
             };
 
-            tx.send(r).unwrap();
+            let _ = tx.send(r);
         }
         .into_actor(self);
         ctx.wait(fut);
@@ -103,7 +103,7 @@ impl Handler<CacheResult> for RedisCache {
         let con = self.0.get_client();
         let fut = async move {
             let r = con.add_token(&msg).await;
-            tx.send(r).unwrap();
+            let _ = tx.send(r);
         }
         .into_actor(self);
         ctx.wait(fut);
@@ -120,7 +120,7 @@ impl Handler<VerifyCaptchaResult> for RedisCache {
         let con = self.0.get_client();
         let fut = async move {
             let r = con.get_token(&msg).await;
-            tx.send(r).unwrap();
+            let _ = tx.send(r);
         }
         .into_actor(self);
         ctx.wait(fut);


### PR DESCRIPTION
Fixes #16.

If the caller drops the oneshot receiver before the Redis operation completes (e.g. an HTTP client disconnects mid-request), `tx.send().unwrap()` panics inside the actor context and the `RedisCache` actor dies permanently — every captcha verification on that instance then fails with `Actor mailbox error` until the process is restarted. We hit this in production today (details in #16).

This ignores the send result in the four `RedisCache` handlers, matching the existing idiom in `master/embedded/master.rs` (`RemoveCaptcha` handler). The synchronous sends in `hashcache.rs` are not affected: there the receiver is still in scope when `send()` runs, so it cannot fail.

Note: `cargo check` on current stable (1.96) fails on master with pre-existing never-type-fallback errors unrelated to this change; the patch compiles cleanly on 1.91.