### PR TITLE
ci: bump actions/cache v2 → v4 so the GitHub workflows can run

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ⚡ Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Follow-up to the offer in #17.

`linux.yml` still pins `actions/cache@v2`. Since Dec 2024 GitHub **auto-fails** any run using `actions/cache@v1/v2` before the job even starts (the toolkit cache service was shut down), so the `stable`/`nightly` jobs go red without ever reaching the build. `v4` is a drop-in replacement — same `path`/`key` inputs, no other changes needed.

This is just the companion to your e3f456f (which refreshed `actions/checkout`); `cache` was the one GitHub still hard-fails on.

Out of scope (left alone on purpose — yours to decide): the `actions-rs/*` actions are archived/Node12 and emit deprecation warnings, and `actions-rs/clippy-check@v1` can't post annotations from fork PRs (`Resource not accessible by integration`). Those only warn; they don't hard-fail the run like `cache@v2` does.